### PR TITLE
Limit cython to version 0.24.1

### DIFF
--- a/wizard/openzwave-hassbian.sh
+++ b/wizard/openzwave-hassbian.sh
@@ -13,7 +13,7 @@ apt-get upgrade -y
 apt-get install -y git make
 
 echo "Installing latest version of cython"
-pip3 install --upgrade cython
+pip3 install --upgrade cython==0.24.1
 
 echo "Creating source directory"
 mkdir -p /srv/homeassistant/src


### PR DESCRIPTION
Versions of Cython later than 0.24.1 fails to compile python-openzwave