### PR TITLE
Change input_slider to input_number

### DIFF
--- a/packages/drop-in/light_control.yaml
+++ b/packages/drop-in/light_control.yaml
@@ -89,12 +89,12 @@ script:
 
             {% if brightness is defined and brightness|int(-1) != -1 %}
               {{ brightness|int }}
-            {% elif states.input_slider[brightness_entity] is not none %}
-              {{ states('input_slider.' ~ brightness_entity)|int }}
+            {% elif states.input_number[brightness_entity] is not none %}
+              {{ states('input_number.' ~ brightness_entity)|int }}
             {% elif states.sensor[brightness_entity] is not none %}
               {{ states('sensor.' ~ brightness_entity)|int }}
-            {% elif states.input_slider.global_brightness is not none %}
-              {{ states('input_slider.global_brightness')|int }}
+            {% elif states.input_number.global_brightness is not none %}
+              {{ states('input_number.global_brightness')|int }}
             {% elif states.sensor.global_brightness is not none %}
               {{ states('sensor.global_brightness')|int }}
             {% else %}


### PR DESCRIPTION
Input_slider is no longer used and when I tried using (a previous version) of this script, it would fail on my Travis build. It passed when I changed input_slider to input_number (doc: https://home-assistant.io/components/input_number/)